### PR TITLE
Fixed incorrect number of EVar type arguments

### DIFF
--- a/HaskellEmacs.hs
+++ b/HaskellEmacs.hs
@@ -212,7 +212,7 @@ fromName (S.Symbol str) = str
 fromName (S.Ident  str) = str
 
 exportFunction :: ExportSpec -> Maybe Name
-exportFunction (EVar _ qname)      = unQualifiedName qname
+exportFunction (EVar qname)      = unQualifiedName qname
 exportFunction (EModuleContents _) = Nothing
 exportFunction _                   = Nothing
 


### PR DESCRIPTION
According to https://hackage.haskell.org/package/haskell-src-exts-1.17.1/docs/Language-Haskell-Exts-Syntax.html, EVar accepts only 1 argument
